### PR TITLE
Added newer mongodump version via multi-staging build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM mongo:4.4.15 AS mongo
+
 FROM alpine:3.14
 
 RUN \
@@ -10,13 +12,19 @@ RUN \
     apk add --update --no-cache npm && \
     npm install -g elasticdump && \
     # install mysql client
-	apk add --update --no-cache mariadb-client  && \
+    apk add --update --no-cache mariadb-client  && \
     # install postgresql client
-	apk add --update --no-cache postgresql-client && \
+    apk add --update --no-cache postgresql-client && \
     # install mongodump \
     apk add --update --no-cache mongodb-tools && \
     # install influxdb \
-    apk add --update --no-cache influxdb
+    apk add --update --no-cache influxdb && \
+    # ensure glibc program compability for added mongodump_rc binary
+    apk add --update --no-cache krb5-libs gcompat
+
+WORKDIR /usr/bin/
+COPY --from=mongo /usr/bin/mongodump ./mongodump_rc
+RUN chown root:root /usr/bin/mongodump_rc
 
 ENV BACKUP_ROOT=/backup
 

--- a/README.md
+++ b/README.md
@@ -148,10 +148,12 @@ pgdump:
 # * host is required
 # * port defaults to 27017
 # * username and password are required
+# * dump_version defaults to 3. Choose between mongodump version 3.x.x and 4.x.x. Implemented to avoid failing dumps due to version mismatch.
 mongodump:
   host: mongodb.local
   username: root
   password: s3cr3t
+  dump_version: 4
 
 # Perform a dump of influxdb
 # * host is required

--- a/mongodump.py
+++ b/mongodump.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import logging as log
-from telnetlib import theNULL
 import requests
 from requests.utils import requote_uri
 import os.path


### PR DESCRIPTION
The current container only ships mongodump 3.x.x. I've added mongodump 4.4.15 from the official image. This makes it possible to dump from newer MongoDBs again (which are running version 4.x.x). Otherwise the dumps fail with the following message
> Failed: error creating intents to dump: error creating intents for database config: error counting config.system.indexBuilds: (Unauthorized) not authorized on config to execute command { count: "system.indexBuilds", lsid: { id: UUID("4dda3c58-afd6-46aa-8d06-6663401c604e") },...

as described here https://www.mongodb.com/community/forums/t/user-with-root-role-cannot-access-config-database/9693/6

Added the option to choose between --dump_version 3 and 4 in mongodump.py.

Wrote about it in README.md.