### PR TITLE
Notification Mail Headers

### DIFF
--- a/smtp_client.py
+++ b/smtp_client.py
@@ -33,13 +33,11 @@ class SMTPClient:
 
     def send_mail(self, subject, body):
 
-        message = MIMEMultipart()
+        message = MIMEText(body, "plain")
         message["From"] = self.mail_from
         message["To"] = self.mail_recipient
         message["Subject"] = subject
         message["message-id"] = utils.make_msgid(domain=self.smtp_host)
         message["Date"] = utils.formatdate(localtime=True)
-
-        message.attach(MIMEText(body, "plain"))
 
         self.smtp_client.sendmail(self.mail_from, self.mail_recipient, message.as_string())

--- a/smtp_client.py
+++ b/smtp_client.py
@@ -37,7 +37,7 @@ class SMTPClient:
         message["From"] = self.mail_from
         message["To"] = self.mail_recipient
         message["Subject"] = subject
-        message["msg-id"] = utils.make_msgid(domain=self.smtp_host)
+        message["message-id"] = utils.make_msgid(domain=self.smtp_host)
         message["Date"] = utils.formatdate(localtime=True)
 
         message.attach(MIMEText(body, "plain"))

--- a/smtp_client.py
+++ b/smtp_client.py
@@ -1,4 +1,6 @@
 
+import email.utils as utils
+
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from smtplib import SMTP_SSL
@@ -35,6 +37,8 @@ class SMTPClient:
         message["From"] = self.mail_from
         message["To"] = self.mail_recipient
         message["Subject"] = subject
+        message["msg-id"] = utils.make_msgid(domain=self.smtp_host)
+        message["Date"] = utils.formatdate(localtime=True)
 
         message.attach(MIMEText(body, "plain"))
 


### PR DESCRIPTION
This PR aims to fix issues with mail-delivery.
Platforms like Google expect well formatted mails, if the mail misses some expected headers, it is marked as spam.
With the addition of the headers `message-id` and `Date`, mails should be delivered correctly.
Additionally sending a `MIMEMultipart` mail without the 'multipart' angers some mail systems. Because of this the mail is now sent as plain text.